### PR TITLE
Refactoring signals and streams

### DIFF
--- a/src/main/scala/com/wire/signals/CancellableFuture.scala
+++ b/src/main/scala/com/wire/signals/CancellableFuture.scala
@@ -36,10 +36,11 @@ class CancellableFuture[+A](promise: Promise[A]) extends Awaitable[A] { self =>
 
   def fail(ex: Exception): Boolean = promise.tryFailure(ex)
 
+  @inline
   def onComplete[B](f: Try[A] => B)(implicit executor: ExecutionContext): Unit = future.onComplete(f)
-  
-  def foreach[U](pf: PartialFunction[A, U])(implicit executor: ExecutionContext): Unit = future.foreach(pf)
-  def foreach(pf: A => Any)(implicit executor: ExecutionContext): Unit = future.foreach(pf)
+
+  @inline
+  def foreach[U](pf: A => U)(implicit executor: ExecutionContext): Unit = future.foreach(pf)
 
   def onCancelled(body: => Unit)(implicit executor: ExecutionContext): Unit = future.onComplete {
     case Failure(_: CancelException) => body
@@ -138,9 +139,11 @@ class CancellableFuture[+A](promise: Promise[A]) extends Awaitable[A] { self =>
     }
   }
 
+  @inline
   def flatten[B](implicit executor: ExecutionContext, evidence: A <:< CancellableFuture[B]): CancellableFuture[B] =
     flatMap(x => x)
 
+  @inline
   def zip[B](other: CancellableFuture[B])(implicit executor: ExecutionContext): CancellableFuture[(A, B)] =
     CancellableFuture.zip(self, other)
 

--- a/src/main/scala/com/wire/signals/EventContext.scala
+++ b/src/main/scala/com/wire/signals/EventContext.scala
@@ -67,7 +67,6 @@ trait EventContext {
     }
   }
 
-
   def unregister(observer: Subscription): Unit = lock.synchronized(observers -= observer)
 
   def isContextStarted: Boolean = lock.synchronized(started && !destroyed)

--- a/src/main/scala/com/wire/signals/Signal.scala
+++ b/src/main/scala/com/wire/signals/Signal.scala
@@ -36,15 +36,15 @@ object Signal {
 
   def const[A](v: A): Signal[A] = new ConstSignal[A](Some(v))
 
-  def apply[A, B](s1: Signal[A], s2: Signal[B]): Signal[(A, B)] = new Zip2Signal[A, B](s1, s2)
+  def zip[A, B](s1: Signal[A], s2: Signal[B]): Signal[(A, B)] = new Zip2Signal[A, B](s1, s2)
 
-  def apply[A, B, C](s1: Signal[A], s2: Signal[B], s3: Signal[C]): Signal[(A, B, C)] = new Zip3Signal(s1, s2, s3)
+  def zip[A, B, C](s1: Signal[A], s2: Signal[B], s3: Signal[C]): Signal[(A, B, C)] = new Zip3Signal(s1, s2, s3)
 
-  def apply[A, B, C, D](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D]): Signal[(A, B, C, D)] = new Zip4Signal(s1, s2, s3, s4)
+  def zip[A, B, C, D](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D]): Signal[(A, B, C, D)] = new Zip4Signal(s1, s2, s3, s4)
 
-  def apply[A, B, C, D, E](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D], s5: Signal[E]): Signal[(A, B, C, D, E)] = new Zip5Signal(s1, s2, s3, s4, s5)
+  def zip[A, B, C, D, E](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D], s5: Signal[E]): Signal[(A, B, C, D, E)] = new Zip5Signal(s1, s2, s3, s4, s5)
 
-  def apply[A, B, C, D, E, F](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D], s5: Signal[E], s6: Signal[F]): Signal[(A, B, C, D, E, F)] = new Zip6Signal(s1, s2, s3, s4, s5, s6)
+  def zip[A, B, C, D, E, F](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D], s5: Signal[E], s6: Signal[F]): Signal[(A, B, C, D, E, F)] = new Zip6Signal(s1, s2, s3, s4, s5, s6)
 
   def throttled[A](s: Signal[A], delay: FiniteDuration): Signal[A] = new ThrottlingSignal(s, delay)
 
@@ -60,22 +60,18 @@ object Signal {
 
   def sequence[A](sources: Signal[A]*): Signal[Seq[A]] = new ProxySignal[Seq[A]](sources: _*) {
     override protected def computeValue(current: Option[Seq[A]]): Option[Seq[A]] = {
-      val res = sources map {
-        _.value
-      }
+      val res = sources.map(_.value)
       if (res.exists(_.isEmpty)) None else Some(res.flatten)
     }
   }
 
-  def future[A](future: Future[A]): Signal[A] = returning(new Signal[A]) { signal =>
+  def from[A](future: Future[A]): Signal[A] = returning(new Signal[A]) { signal =>
     future.foreach {
       res => signal.set(Option(res), Some(Threading.executionContext))
     }(Threading.executionContext)
   }
 
-  def apply[A](f: Future[A]): Signal[A] = future(f)
-
-  def wrap[A](initial: A, source: EventStream[A]): Signal[A] = new Signal[A](Some(initial)) {
+  def from[A](initial: A, source: EventStream[A]): Signal[A] = new Signal[A](Some(initial)) {
     private lazy val subscription = source {
       publish
     }(EventContext.Global)
@@ -85,9 +81,7 @@ object Signal {
     override protected def onUnwire(): Unit = subscription.disable()
   }
 
-  def apply[A](initial: A, source: EventStream[A]): Signal[A] = wrap(initial, source)
-
-  def wrap[A](source: EventStream[A]): Signal[A] = new Signal[A](None) {
+  def from[A](source: EventStream[A]): Signal[A] = new Signal[A](None) {
     private lazy val subscription = source {
       publish
     }(EventContext.Global)
@@ -96,8 +90,6 @@ object Signal {
 
     override protected def onUnwire(): Unit = subscription.disable()
   }
-
-  def apply[A](source: EventStream[A]): Signal[A] = wrap(source)
 }
 
 class SourceSignal[A](v: Option[A] = None) extends Signal(v) {
@@ -186,7 +178,7 @@ class Signal[A](@volatile protected[signals] var value: Option[A] = None)
 
   def filter(f: A => Boolean): Signal[A] = new FilterSignal(this, f)
 
-  def withFilter(f: A => Boolean): Signal[A] = new FilterSignal(this, f)
+  final def withFilter(f: A => Boolean): Signal[A] = filter(f)
 
   def ifTrue(implicit ev: A =:= Boolean): Signal[Unit] = collect { case true => () }
 
@@ -254,7 +246,7 @@ trait NoAutowiring { self: Signal[_] =>
   * Immutable signal value. Can be used whenever some constant or empty signal is needed.
   * Using immutable signals in flatMap chains should have better performance compared to regular signals with the same value.
   */
-final class ConstSignal[A](v: Option[A]) extends Signal[A](v) with NoAutowiring {
+final private[signals] class ConstSignal[A](v: Option[A]) extends Signal[A](v) with NoAutowiring {
   override def subscribe(l: SignalListener): Unit = ()
 
   override def unsubscribe(l: SignalListener): Unit = ()
@@ -266,7 +258,7 @@ final class ConstSignal[A](v: Option[A]) extends Signal[A](v) with NoAutowiring 
     throw new UnsupportedOperationException("Const signal can not be changed")
 }
 
-final class ThrottlingSignal[A](source: Signal[A], delay: FiniteDuration) extends ProxySignal[A](source) {
+final private[signals] class ThrottlingSignal[A](source: Signal[A], delay: FiniteDuration) extends ProxySignal[A](source) {
 
   import scala.concurrent.duration._
 
@@ -287,7 +279,7 @@ final class ThrottlingSignal[A](source: Signal[A], delay: FiniteDuration) extend
     }
 }
 
-final class FlatMapSignal[A, B](source: Signal[A], f: A => Signal[B]) extends Signal[B] with SignalListener {
+final private[signals] class FlatMapSignal[A, B](source: Signal[A], f: A => Signal[B]) extends Signal[B] with SignalListener {
   private val Empty = Signal.empty[B]
 
   private object wiringMonitor
@@ -347,27 +339,28 @@ abstract class ProxySignal[A](sources: Signal[_]*) extends Signal[A] with Signal
   protected def computeValue(current: Option[A]): Option[A]
 }
 
-final class ScanSignal[A, B](source: Signal[A], zero: B, f: (B, A) => B) extends ProxySignal[B](source) {
+final private[signals] class ScanSignal[A, B](source: Signal[A], zero: B, f: (B, A) => B) extends ProxySignal[B](source) {
   value = Some(zero)
 
   override protected def computeValue(current: Option[B]): Option[B] =
     source.value map { v => f(current.getOrElse(zero), v) } orElse current
 }
 
-final class FilterSignal[A](source: Signal[A], f: A => Boolean) extends ProxySignal[A](source) {
+final private[signals] class FilterSignal[A](source: Signal[A], f: A => Boolean) extends ProxySignal[A](source) {
   override protected def computeValue(current: Option[A]): Option[A] = source.value.filter(f)
 }
 
-final class MapSignal[A, B](source: Signal[A], f: A => B) extends ProxySignal[B](source) {
+final private[signals]class MapSignal[A, B](source: Signal[A], f: A => B) extends ProxySignal[B](source) {
   override protected def computeValue(current: Option[B]): Option[B] = source.value map f
 }
 
-final class Zip2Signal[A, B](s1: Signal[A], s2: Signal[B]) extends ProxySignal[(A, B)](s1, s2) {
+final private[signals] class Zip2Signal[A, B](s1: Signal[A], s2: Signal[B]) extends ProxySignal[(A, B)](s1, s2) {
   override protected def computeValue(current: Option[(A, B)]): Option[(A, B)] =
     for (a <- s1.value; b <- s2.value) yield (a, b)
 }
 
-final class Zip3Signal[A, B, C](s1: Signal[A], s2: Signal[B], s3: Signal[C]) extends ProxySignal[(A, B, C)](s1, s2, s3) {
+final private[signals] class Zip3Signal[A, B, C](s1: Signal[A], s2: Signal[B], s3: Signal[C])
+  extends ProxySignal[(A, B, C)](s1, s2, s3) {
   override protected def computeValue(current: Option[(A, B, C)]): Option[(A, B, C)] =
     for {
       a <- s1.value
@@ -376,7 +369,7 @@ final class Zip3Signal[A, B, C](s1: Signal[A], s2: Signal[B], s3: Signal[C]) ext
     } yield (a, b, c)
 }
 
-final class Zip4Signal[A, B, C, D](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D])
+final private[signals] class Zip4Signal[A, B, C, D](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D])
   extends ProxySignal[(A, B, C, D)](s1, s2, s3, s4) {
   override protected def computeValue(current: Option[(A, B, C, D)]): Option[(A, B, C, D)] =
     for {
@@ -387,7 +380,7 @@ final class Zip4Signal[A, B, C, D](s1: Signal[A], s2: Signal[B], s3: Signal[C], 
     } yield (a, b, c, d)
 }
 
-final class Zip5Signal[A, B, C, D, E](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D], s5: Signal[E])
+final private[signals] class Zip5Signal[A, B, C, D, E](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D], s5: Signal[E])
   extends ProxySignal[(A, B, C, D, E)](s1, s2, s3, s4, s5) {
   override protected def computeValue(current: Option[(A, B, C, D, E)]): Option[(A, B, C, D, E)] =
     for {
@@ -399,7 +392,8 @@ final class Zip5Signal[A, B, C, D, E](s1: Signal[A], s2: Signal[B], s3: Signal[C
     } yield (a, b, c, d, e)
 }
 
-final class Zip6Signal[A, B, C, D, E, F](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D], s5: Signal[E], s6: Signal[F]) extends ProxySignal[(A, B, C, D, E, F)](s1, s2, s3, s4, s5, s6) {
+final private[signals] class Zip6Signal[A, B, C, D, E, F](s1: Signal[A], s2: Signal[B], s3: Signal[C], s4: Signal[D], s5: Signal[E], s6: Signal[F])
+  extends ProxySignal[(A, B, C, D, E, F)](s1, s2, s3, s4, s5, s6) {
   override protected def computeValue(current: Option[(A, B, C, D, E, F)]): Option[(A, B, C, D, E, F)] = for {
     a <- s1.value
     b <- s2.value
@@ -410,12 +404,12 @@ final class Zip6Signal[A, B, C, D, E, F](s1: Signal[A], s2: Signal[B], s3: Signa
   } yield (a, b, c, d, e, f)
 }
 
-final class FoldLeftSignal[A, B](sources: Signal[A]*)(v: B)(f: (B, A) => B) extends ProxySignal[B](sources: _*) {
+final private[signals] class FoldLeftSignal[A, B](sources: Signal[A]*)(v: B)(f: (B, A) => B) extends ProxySignal[B](sources: _*) {
   override protected def computeValue(current: Option[B]): Option[B] =
     sources.foldLeft(Option(v))((mv, signal) => for (a <- mv; b <- signal.value) yield f(a, b))
 }
 
-final class PartialUpdateSignal[A, B](source: Signal[A])(select: A => B) extends ProxySignal[A](source) {
+final private[signals] class PartialUpdateSignal[A, B](source: Signal[A])(select: A => B) extends ProxySignal[A](source) {
 
   private object updateMonitor
 
@@ -434,6 +428,3 @@ final class PartialUpdateSignal[A, B](source: Signal[A])(select: A => B) extends
 
   override protected def computeValue(current: Option[A]): Option[A] = source.value
 }
-
-
-

--- a/src/main/scala/com/wire/signals/utils/package.scala
+++ b/src/main/scala/com/wire/signals/utils/package.scala
@@ -1,27 +1,6 @@
 package com.wire.signals
 
-import java.util.concurrent.atomic.AtomicReference
-
-import scala.annotation.tailrec
-import scala.concurrent.duration.{FiniteDuration, _}
-import scala.concurrent.{Await, ExecutionContext, Future}
-
 package object utils {
-  @tailrec
-  def compareAndSet[A](ref: AtomicReference[A])(updater: A => A): A = {
-    val current = ref.get
-    val updated = updater(current)
-    if (ref.compareAndSet(current, updated)) updated
-    else compareAndSet(ref)(updater)
-  }
-
-  def withDelay[T](body: => T, delay: FiniteDuration = 300.millis)(implicit ec: ExecutionContext): CancellableFuture[T] =
-    CancellableFuture.delayed(delay)(body)
-
-  val DefaultTimeout: FiniteDuration = 5.seconds
-
-  def result[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): A =
-    Await.result(future, duration)
 
   object returning {
     @inline

--- a/src/test/scala/com/wire/signals/AggregatingSignalSpec.scala
+++ b/src/test/scala/com/wire/signals/AggregatingSignalSpec.scala
@@ -19,8 +19,7 @@ package com.wire.signals
 
 import org.scalatest._
 import Threading._
-import com.wire.signals.testutils.Publisher
-import utils._
+import testutils._
 
 import scala.concurrent.Promise
 

--- a/src/test/scala/com/wire/signals/ButtonSignalSpec.scala
+++ b/src/test/scala/com/wire/signals/ButtonSignalSpec.scala
@@ -18,7 +18,7 @@
 package com.wire.signals
 
 import org.scalatest.{FeatureSpec, Matchers}
-import utils._
+import testutils._
 
 class ButtonSignalSpec extends FeatureSpec with Matchers {
 

--- a/src/test/scala/com/wire/signals/Follower.scala
+++ b/src/test/scala/com/wire/signals/Follower.scala
@@ -19,7 +19,8 @@ package com.wire.signals
 
 import java.util.concurrent.atomic.AtomicReference
 
-import utils._
+import com.wire.signals.utils.returning
+import testutils._
 
 case class Follower[A](signal: Signal[A]) {
   private val receivedValues = new AtomicReference(Vector.empty[A])

--- a/src/test/scala/com/wire/signals/SignalSpec.scala
+++ b/src/test/scala/com/wire/signals/SignalSpec.scala
@@ -20,7 +20,6 @@ package com.wire.signals
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, CyclicBarrier, TimeUnit}
 
-import utils._
 import testutils._
 import org.scalatest._
 import Threading.executionContext
@@ -156,7 +155,7 @@ class SignalSpec extends FeatureSpec with Matchers with OptionValues with Before
         sub.destroy()
       }))
       val adding = Future.sequence(Seq.fill(25)(add(chaosBarrier)))
-      val sending = Future.traverse(1 to 25)(n => Future(blocking {
+      val sending = Future.traverse((1 to 25).toList)(n => Future(blocking {
         chaosBarrier.await()
         s ! n
       }))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2"
+version in ThisBuild := "0.2.1"


### PR DESCRIPTION
Until now, the naming of methods which created signals and event streams from initial data was quite inconsistent.
We had `wrap` to wrap a signal over a stream, but also `future` to wrap a signal over a future, and there was `zip`
to zip one signal with another, but also an `apply` which was doing the same thing, but for zipping event streams
we used `union` instead, and anyway `apply` in signals was used to create cosnt signals from any data.

This PR tries to make sense out of it. `Signal.apply` is now used solely to create `ConstSignal`. It takes only one parameter. For transformation of a future into a signal or an event stream into a signal, or a signal into an event stream (even more transformers will be coming in next PRs) we now have `Signal.from` and `EventStream.from`. And for zipping a few event streams or signals together, we have `Signal.zip` and `EventStream.zip`.

I also used this PR to hide a few subclasses of `Signal` and `EventStream` from API. The user is still able to create them with methods of respective companion objects, but will not be able to do it directly. This is an approach I'd like to take with the whole library: smart constructors and special methods in the companion object instead of direct constructors.