### PR TITLE
Fix documentation errors

### DIFF
--- a/src/main/scala/com/wire/signals/ClockSignal.scala
+++ b/src/main/scala/com/wire/signals/ClockSignal.scala
@@ -32,7 +32,7 @@ object ClockSignal {
     * @param clock The clock configured to produce the new values of the signal.
     * @param ec The execution context in which the clock signal works. If the context is busy, the value of the signal
     *           may be updated with a delay.
-    * @return A new clock signal with the value type [[Instant]]
+    * @return A new clock signal with the value type [[org.threeten.bp.Instant]]
     */
   def apply(interval: FiniteDuration, clock: Clock = Clock.systemUTC())(implicit ec: ExecutionContext = Threading.defaultContext): ClockSignal =
     new ClockSignal(interval, clock)

--- a/src/main/scala/com/wire/signals/Subscribable.scala
+++ b/src/main/scala/com/wire/signals/Subscribable.scala
@@ -31,7 +31,7 @@ package com.wire.signals
   * "source subscribers" of this type when a new event comes (`Subscribable` doesn't care what method will be used
   * to do it). In this case, the "source subscriber" is `EventSubscriber`.
   *
-  * Please not that [[SourceSubscriber]] is a trait or a class type. This is different from another generic type called
+  * Please not that `SourceSubscriber` is a trait or a class type. This is different from another generic type called
   * [[Subscription.Subscriber]] which is a function type used to create a [[Subscription]]. We will get to it in a second.
   *
   * So far, there are no event subscribers yet, which means that if we publish anything to this stream, nothing will happen.


### PR DESCRIPTION
Scaladoc reports a number of issues where it's not able to link the classes mentioned in the documentation to their sources.
In this PR I will try to address those issues. (more commits are planned)