### PR TITLE
fix: ThrottledSignal sometimes ignores newer values

### DIFF
--- a/src/test/scala/com/wire/signals/EventStreamSpec.scala
+++ b/src/test/scala/com/wire/signals/EventStreamSpec.scala
@@ -289,7 +289,7 @@ class EventStreamSpec extends munit.FunSuite {
     val waitForMe = Promise[Unit]()
 
     mappedAsync.foreach { n =>
-      resultsAsync.addOne(n)
+      resultsAsync += n
       if (resultsAsync.length == 4) waitForMe.success(())
     }
 

--- a/src/test/scala/com/wire/signals/SignalSpec.scala
+++ b/src/test/scala/com/wire/signals/SignalSpec.scala
@@ -136,6 +136,7 @@ class SignalSpec extends munit.FunSuite {
   }
 
   test("Many concurrent subscriber changes") {
+    implicit val executionContext: ExecutionContext = UnlimitedDispatchQueue()
     val barrier = new CyclicBarrier(50)
     val num = new AtomicInteger(0)
     val s = Signal(0)


### PR DESCRIPTION
With the old implementation of ThrottledSignal, if the signal is initialized with a sequence of quick changes,
it is possible that it will store the first value and ignore the others. See https://github.com/wireapp/wire-signals/issues/47.
The new implementation makes sure the last value from the sequence is emited.