### PR TITLE
CancellableFuture tests and refactoring

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,12 +1,13 @@
 // based on http://caryrobbins.com/dev/sbt-publishing/
 
-lazy val scala213 = "2.13.4"
+lazy val scala213 = "2.13.5"
 lazy val scala212 = "2.12.12"
 lazy val scala211 = "2.11.12"
 lazy val supportedScalaVersions = List(scala213, scala212, scala211)
 
 ThisBuild / organization := "com.wire"
 ThisBuild / scalaVersion := scala213
+Test / scalaVersion := scala213
 
 val standardOptions = Seq(
   "-deprecation",
@@ -48,7 +49,7 @@ val scala213Options = Seq(
 homepage := Some(url("https://github.com/wireapp/wire-signals"))
 licenses := Seq("GPL 3.0" -> url("https://www.gnu.org/licenses/gpl-3.0.en.html"))
 publishMavenStyle := true
-publishArtifact in Test := false
+Test / publishArtifact := false
 pomIncludeRepository := { _ => false }
 ThisBuild / publishTo := {
   val nexus = "https://oss.sonatype.org/"
@@ -80,8 +81,6 @@ publishMavenStyle := true
 publishConfiguration      := publishConfiguration.value.withOverwrite(true)
 publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true)
 publishM2Configuration    := publishM2Configuration.value.withOverwrite(true)
-
-Test / scalaVersion := scala213
 
 lazy val root = (project in file("."))
   .settings(

--- a/core/project/build.properties
+++ b/core/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.6
+sbt.version = 1.5.0

--- a/core/src/main/scala/com/wire/signals/CancellableFuture.scala
+++ b/core/src/main/scala/com/wire/signals/CancellableFuture.scala
@@ -241,7 +241,7 @@ object CancellableFuture {
 }
 
 /** `CancellableFuture` is an object that for all practical uses works like a future but enables the user to cancel the operation.
-  * A cancelled future fails with `CancellableFuture.CancelException` so the subscriber can differentiate between thisand other
+  * A cancelled future fails with `CancellableFuture.CancelException` so the subscriber can differentiate between this and other
   * failure reasons.
   *
   * @see https://github.com/wireapp/wire-signals/wiki/Overview

--- a/core/src/main/scala/com/wire/signals/EventStream.scala
+++ b/core/src/main/scala/com/wire/signals/EventStream.scala
@@ -272,15 +272,16 @@ class EventStream[E] protected () extends EventRelay[E, EventSubscriber[E]] {
     *                future is finished or cancelled.
     * @return A cancellable future which will finish with the next event emitted by the event stream.
     */
-  final def next(implicit context: EventContext = EventContext.Global): CancellableFuture[E] = {
+  final def next(implicit context: EventContext = EventContext.Global, executionContext: ExecutionContext = Threading.defaultContext): CancellableFuture[E] = {
     val p = Promise[E]()
     val o = onCurrent { p.trySuccess }
-    p.future.onComplete(_ => o.destroy())(Threading.defaultContext)
+    p.future.onComplete(_ => o.destroy())
     new CancellableFuture(p)
   }
 
   /** A shorthand for `next` which additionally unwraps the cancellable future */
-  @inline final def future(implicit context: EventContext = EventContext.Global): Future[E] = next.future
+  @inline final def future(implicit context: EventContext = EventContext.Global, executionContext: ExecutionContext = Threading.defaultContext): Future[E] =
+    next.future
 
   /** An alias to the `future` method. */
   @inline final def head: Future[E] = future

--- a/core/src/main/scala/com/wire/signals/EventStream.scala
+++ b/core/src/main/scala/com/wire/signals/EventStream.scala
@@ -276,7 +276,7 @@ class EventStream[E] protected () extends EventRelay[E, EventSubscriber[E]] {
     val p = Promise[E]()
     val o = onCurrent { p.trySuccess }
     p.future.onComplete(_ => o.destroy())
-    new CancellableFuture(p)
+    new Cancellable(p)
   }
 
   /** A shorthand for `next` which additionally unwraps the cancellable future */

--- a/core/src/test/scala/com/wire/signals/CancellableFutureSpec.scala
+++ b/core/src/test/scala/com/wire/signals/CancellableFutureSpec.scala
@@ -1,0 +1,160 @@
+package com.wire.signals
+
+import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration._
+import testutils._
+
+class CancellableFutureSpec extends munit.FunSuite {
+  test("Transform between a future and a cancellable future") {
+    import CancellableFuture._
+    val f1: Future[Unit] = Future.successful(())
+    val cf1 = f1.toCancellable
+    cf1 match {
+      case _: CancellableFuture[Unit] =>
+      case _ => fail("Future[Unit] should be transformed into CancellableFuture[Unit]")
+    }
+
+    val f2 = cf1.future
+    f2 match {
+      case _: Future[Unit] =>
+      case _ => fail("CancellableFuture[Unit] should wrap over Future[Unit]")
+    }
+
+    val cf2 = CancellableFuture.lift(f2)
+    cf2 match {
+      case _: CancellableFuture[Unit] =>
+      case _ => fail("Future[Unit] should be lifted into CancellableFuture[Unit]")
+    }
+  }
+
+  test("Create a cancellable future from the body") {
+    import Threading.defaultContext
+    var res = 0
+
+    val cf = CancellableFuture { res = 1 }
+
+    await(cf)
+
+    assertEquals(res, 1)
+  }
+
+  test("Create an already completed cancellable future from the body") {
+    var res = 0
+
+    val cf = CancellableFuture.successful { res = 1 }
+
+    assertEquals(res, 1)
+  }
+
+  test("Create an already failed cancellable future") {
+    val cf = CancellableFuture.failed(new IllegalArgumentException)
+    assert(cf.isCompleted)
+  }
+
+  test("Create an already cancelled cancellable future") {
+    val cf = CancellableFuture.cancelled()
+    assert(cf.isCompleted)
+  }
+
+
+  test(" A cancellable future succeeds just like a standard one") {
+    import Threading.defaultContext
+    var res = 0
+
+    val p = Promise[Int]()
+    val f = p.future
+    f.foreach { res = _ }
+
+    val cf = CancellableFuture.lift(
+      future = f,
+      onCancel = { res = -1 }
+    )
+
+    p.success(1)
+    await(f)
+    assertEquals(res, 1)
+
+    assert(!cf.cancel())
+    await(cf)
+    assertEquals(res, 1) // cancellation doesn't change the result after the promise is completed
+  }
+
+  test("A cancellable future can be cancelled (wow! who would expect that)"){
+    import Threading.defaultContext
+    var res = 0
+
+    val p = Promise[Int]()
+    val f = p.future
+    f.foreach { res = _ }
+
+    val cf = CancellableFuture.lift(
+      future = f,
+      onCancel = { res = -1 }
+    )
+
+    assert(cf.cancel())
+    await(cf)
+    assertEquals(res, -1)
+
+    p.success(1)
+    await(f)
+    assertEquals(res, -1) // completing the promise doesn't change the result after cf is cancelled
+  }
+
+  test("A cancellable future can't be cancelled twice") {
+    import Threading.defaultContext
+    var res = 0
+
+    val p = Promise[Int]()
+
+    val cf = CancellableFuture.lift(
+      future = p.future,
+      onCancel = { res -= 1 }
+    )
+
+    assert(cf.cancel())
+    await(cf)
+    assertEquals(res, -1)
+
+    assert(!cf.cancel()) // if cancelling cf twice worked, this would be true
+    await(cf)
+    assertEquals(res, -1) // if cancelling cf twice worked, this would be -2
+  }
+
+  test(" Complete a delayed cancellable future") {
+    import Threading.defaultContext
+    var res = 0
+
+    val cf: CancellableFuture[Unit] = CancellableFuture.delay(500.millis).map { _ => res = 1 }
+    assertEquals(res, 0)
+
+    await(cf)
+
+    assertEquals(res, 1)
+  }
+
+  test("Complete a cancellable future delayed in another way") {
+    import Threading.defaultContext
+    var res = 0
+
+    val cf: CancellableFuture[Unit] = CancellableFuture.delayed(500.millis) { res = 1 }
+    assertEquals(res, 0)
+
+    await(cf)
+
+    assertEquals(res, 1)
+  }
+
+  test("Cancel a delayed future") {
+    import Threading.defaultContext
+    var res = 0
+
+    val cf: CancellableFuture[Unit] = CancellableFuture.delayed(500.millis) { res = 1 }
+    assertEquals(res, 0)
+    assert(cf.cancel())
+
+    await(cf)
+
+    assertEquals(res, 0)
+  }
+}

--- a/core/src/test/scala/com/wire/signals/CancellableFutureSpec.scala
+++ b/core/src/test/scala/com/wire/signals/CancellableFutureSpec.scala
@@ -242,7 +242,7 @@ class CancellableFutureSpec extends munit.FunSuite {
   test("Cancel a sequence of cancellable futures") {
     import Threading.defaultContext
 
-    val onCancel = EventStream[Unit]()
+    val onCancel = Signal(false)
 
     var timestamps = Seq.empty[Long]
     val offset = System.currentTimeMillis
@@ -251,11 +251,10 @@ class CancellableFutureSpec extends munit.FunSuite {
     val cf3 = CancellableFuture.delayed(500.millis) { timestamps :+= (System.currentTimeMillis - offset) }
     val cf4 = CancellableFuture.delayed(600.millis) { timestamps :+= (System.currentTimeMillis - offset) }
 
-    val cfSeq = CancellableFuture.sequence(Seq(cf1, cf2, cf3, cf4), Some(() => onCancel ! ()))
+    val cfSeq = CancellableFuture.sequence(Seq(cf1, cf2, cf3, cf4), Some(() => onCancel ! true))
     Thread.sleep(50)
     cfSeq.cancel()
-
-    waitForResult(onCancel, ())
+    waitForResult(onCancel, true)
 
     assert(timestamps.isEmpty)
   }

--- a/core/src/test/scala/com/wire/signals/CancellableFutureSpec.scala
+++ b/core/src/test/scala/com/wire/signals/CancellableFutureSpec.scala
@@ -4,13 +4,11 @@ import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 import testutils._
 
-import scala.util.{Failure, Success, Try}
-
 class CancellableFutureSpec extends munit.FunSuite {
   test("Transform between a future and a cancellable future") {
     import CancellableFuture._
     val f1: Future[Unit] = Future.successful(())
-    val cf1 = f1.toCancellable
+    val cf1 = f1.lift
     cf1 match {
       case _: CancellableFuture[Unit] =>
       case _ => fail("Future[Unit] should be transformed into CancellableFuture[Unit]")
@@ -67,8 +65,7 @@ class CancellableFutureSpec extends munit.FunSuite {
     val f = p.future
     f.foreach { res = _ }
 
-    val cf = new CancellableFuture(p)
-    cf.onCancelled{ res = -1 }
+    val cf = new CancellableFuture(p, Some { () => res = -1 })
 
     p.success(1)
     assertEquals(result(f), 1)
@@ -80,43 +77,40 @@ class CancellableFutureSpec extends munit.FunSuite {
 
   test("A cancellable future can be cancelled (wow! who would expect that)"){
     import Threading.defaultContext
-    var res = 0
+    val res = Signal(0)
 
     val p = Promise[Int]()
     val f = p.future
-    f.foreach { res = _ }
+    f.foreach { res ! _ }
 
-    val cf = new CancellableFuture(p)
-    cf.onCancelled { res = -1 }
+    val cf = new CancellableFuture(p, Some { () => res ! -1 })
 
     assert(cf.cancel())
     await(cf)
-    assertEquals(res, -1)
+    waitForResult(res, -1)
     intercept[java.lang.IllegalStateException](p.success(1)) // the promise is already cancelled
   }
 
   test("A cancellable future can't be cancelled twice") {
     import Threading.defaultContext
-    var res = 0
+    val res = Signal(0)
 
     val p = Promise[Int]()
     val f = p.future
-    f.foreach { res = _ }
+    f.foreach { res ! _ }
 
-    val cf = new CancellableFuture(p)
-    cf.onCancelled{ res = -1 }
+    val cf = new CancellableFuture(p, Some { () => res ! -1 })
 
     assert(cf.cancel())
     await(cf)
-    assertEquals(res, -1)
+    waitForResult(res, -1)
 
     assert(!cf.cancel()) // if cancelling cf twice worked, this would be true
     await(cf)
-    assertEquals(res, -1) // if cancelling cf twice worked, this would be -2*/
+    waitForResult(res, -1) // if cancelling cf twice worked, this would be -2*/
   }
 
   test(" Complete a delayed cancellable future") {
-    import Threading.defaultContext
     var res = 0
 
     val cf: CancellableFuture[Unit] = CancellableFuture.delay(500.millis).map { _ => res = 1 }
@@ -187,16 +181,130 @@ class CancellableFutureSpec extends munit.FunSuite {
     var theFlag = false // this should stay false if the future was cancelled (but it won't)
     var semaphore = false
     val f1: Future[Unit] = Future {
-      while(!semaphore) Thread.sleep(100L)
+      while (!semaphore) Thread.sleep(100L)
       theFlag = true
     }
 
-    val cf1 = f1.toCancellable
+    val cf1 = f1.lift
     assert(!cf1.cancel())
 
     semaphore = true
     await(f1)
 
     assert(theFlag)
+  }
+
+  test("Traverse a sequence of tasks") {
+    import Threading.defaultContext
+
+    var timestamps = Seq.empty[Long]
+    val offset = System.currentTimeMillis
+    val millis = Seq(200, 100, 50, 150)
+    val cf = CancellableFuture.traverse(millis) { t =>  CancellableFuture.delayed(t.millis) { timestamps :+= (System.currentTimeMillis - offset) }}
+
+    await(cf)
+    assert(timestamps.size == 4)
+  }
+
+  test("Traverse a sequence of tasks sequentially") {
+    import Threading.defaultContext
+
+    var timestamps = Seq.empty[(Int, Long)]
+    val offset = System.currentTimeMillis
+    val millis = Seq((1, 200), (2, 100), (3, 50), (4, 150))
+    val cf = CancellableFuture.traverseSequential(millis) {
+      case (i, t) =>  CancellableFuture.delayed(t.millis) { timestamps :+= (i, System.currentTimeMillis - offset) }
+    }
+    await(cf)
+    assert(timestamps.size == 4)
+
+    // indices of finished tasks are in the same order as the tuples
+    timestamps.map(_._1).zip(millis.map(_._1)).foreach { case (t, m) => assertEquals(t, m) }
+  }
+
+  test("Traverse a sequence of tasks - quickest goes first") {
+    import Threading.defaultContext
+
+    var timestamps = Seq.empty[(Int, Long)]
+    val offset = System.currentTimeMillis
+    val millis = Seq((1, 200), (2, 100), (3, 50), (4, 150))
+    val cf = CancellableFuture.traverse(millis) {
+      case (i, t) =>  CancellableFuture.delayed(t.millis) { timestamps :+= (i, System.currentTimeMillis - offset) }
+    }
+    await(cf)
+
+    assert(timestamps.size == 4)
+
+    // indices of finished tasks are in the order from the one which finished first to the last
+    timestamps.map(_._1).zip(millis.sortBy(_._2).map(_._1)).foreach { case (t, m) => assertEquals(t, m) }
+  }
+
+  test("Cancel a sequence of cancellable futures") {
+    import Threading.defaultContext
+
+    val onCancel = EventStream[Unit]()
+
+    var timestamps = Seq.empty[Long]
+    val offset = System.currentTimeMillis
+    val cf1 = CancellableFuture.delayed(300.millis) { timestamps :+= (System.currentTimeMillis - offset) }
+    val cf2 = CancellableFuture.delayed(400.millis) { timestamps :+= (System.currentTimeMillis - offset) }
+    val cf3 = CancellableFuture.delayed(500.millis) { timestamps :+= (System.currentTimeMillis - offset) }
+    val cf4 = CancellableFuture.delayed(600.millis) { timestamps :+= (System.currentTimeMillis - offset) }
+
+    val cfSeq = CancellableFuture.sequence(Seq(cf1, cf2, cf3, cf4), Some(() => onCancel ! ()))
+    Thread.sleep(50)
+    cfSeq.cancel()
+
+    waitForResult(onCancel, ())
+
+    assert(timestamps.isEmpty)
+  }
+
+  test("After a successful execution of one future in the sequence, cancel the rest") {
+    import Threading.defaultContext
+
+    val onCancel = EventStream[Unit]()
+
+    var timestamps = Seq.empty[Long]
+    val offset = System.currentTimeMillis
+    val cancelOthers = () => {
+      timestamps :+= (System.currentTimeMillis - offset)
+      onCancel ! ()
+    }
+    val cf1 = CancellableFuture.delayed(300.millis)(cancelOthers())
+    val cf2 = CancellableFuture.delayed(50.millis)(cancelOthers())
+    val cf3 = CancellableFuture.delayed(100.millis)(cancelOthers())
+    val cf4 = CancellableFuture.delayed(200.millis)(cancelOthers())
+
+    val cfSeq = CancellableFuture.sequence(Seq(cf1, cf2, cf3, cf4))
+    onCancel.foreach(_ => cfSeq.cancel())
+
+    waitForResult(onCancel, ())
+    await(cfSeq)
+
+    assertEquals(timestamps.size, 1)
+  }
+
+  test("Cancel a traverse after the first task finishes with success") {
+    import Threading.defaultContext
+
+    val onCancel = EventStream[Unit]()
+    var timestamps = Seq.empty[Long]
+    val offset = System.currentTimeMillis
+    val cancelOthers = () => {
+      timestamps :+= (System.currentTimeMillis - offset)
+      onCancel ! ()
+    }
+
+    val millis = Seq(400, 500, 50, 300)
+    val cf = CancellableFuture.traverse(millis) { t =>
+      CancellableFuture.delayed(t.millis) { cancelOthers() }
+    }
+    onCancel.foreach(_ => cf.cancel())
+
+    waitForResult(onCancel, ())
+    await(cf)
+
+    assertEquals(timestamps.size, 1)
   }
 }

--- a/core/src/test/scala/com/wire/signals/testutils/package.scala
+++ b/core/src/test/scala/com/wire/signals/testutils/package.scala
@@ -56,14 +56,13 @@ package object testutils {
 
   val DefaultTimeout: FiniteDuration = 5.seconds
 
-  def result[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): A =
-    Await.result(future, duration)
+  def result[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): A = Await.result(future, duration)
 
   @inline def await[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): Unit = tryResult(future)
 
   def tryResult[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): Try[A] =
     try {
-      Try(Await.result(future, duration))
+      Try(result(future))
     } catch {
       case t: Throwable => Failure(t)
     }

--- a/core/src/test/scala/com/wire/signals/testutils/package.scala
+++ b/core/src/test/scala/com/wire/signals/testutils/package.scala
@@ -59,6 +59,8 @@ package object testutils {
   def result[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): A =
     Await.result(future, duration)
 
+  @inline def await[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): Unit = tryResult(future)
+
   def tryResult[A](future: Future[A])(implicit duration: FiniteDuration = DefaultTimeout): Try[A] =
     try {
       Try(Await.result(future, duration))

--- a/core/src/test/scala/com/wire/signals/testutils/package.scala
+++ b/core/src/test/scala/com/wire/signals/testutils/package.scala
@@ -67,7 +67,6 @@ package object testutils {
       case t: Throwable => Failure(t)
     }
 
-
   def waitForResult[V](signal: Signal[V], expected: V, timeout: FiniteDuration): Boolean = {
     val offset = System.currentTimeMillis()
     while (System.currentTimeMillis() - offset < timeout.toMillis) {
@@ -83,9 +82,7 @@ package object testutils {
     false
   }
 
-  def waitForResult[V](signal: Signal[V], expected: V): Boolean = {
-    waitForResult(signal, expected, DefaultTimeout)
-  }
+  def waitForResult[V](signal: Signal[V], expected: V): Boolean = waitForResult(signal, expected, DefaultTimeout)
 
   def waitForResult[E](stream: EventStream[E], expected: E, timeout: FiniteDuration): Boolean = {
     val offset = System.currentTimeMillis()
@@ -102,9 +99,7 @@ package object testutils {
     false
   }
 
-  def waitForResult[E](stream: EventStream[E], expected: E): Boolean = {
-    waitForResult(stream, expected, DefaultTimeout)
-  }
+  def waitForResult[E](stream: EventStream[E], expected: E): Boolean = waitForResult(stream, expected, DefaultTimeout)
 
   /**
     * Very useful for checking that something DOESN'T happen (e.g., ensure that a signal doesn't get updated after

--- a/extensions/build.sbt
+++ b/extensions/build.sbt
@@ -1,12 +1,13 @@
 // based on http://caryrobbins.com/dev/sbt-publishing/
 
-lazy val scala213 = "2.13.4"
+lazy val scala213 = "2.13.5"
 lazy val scala212 = "2.12.12"
 lazy val scala211 = "2.11.12"
 lazy val supportedScalaVersions = List(scala213, scala212, scala211)
 
 ThisBuild / organization := "com.wire"
 ThisBuild / scalaVersion := scala213
+Test / scalaVersion := scala213
 
 val standardOptions = Seq(
   "-deprecation",
@@ -48,7 +49,7 @@ val scala213Options = Seq(
 homepage := Some(url("https://github.com/wireapp/wire-signals"))
 licenses := Seq("GPL 3.0" -> url("https://www.gnu.org/licenses/gpl-3.0.en.html"))
 publishMavenStyle := true
-publishArtifact in Test := false
+Test / publishArtifact := false
 pomIncludeRepository := { _ => false }
 ThisBuild / publishTo := {
   val nexus = "https://oss.sonatype.org/"

--- a/extensions/project/build.properties
+++ b/extensions/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.6
+sbt.version = 1.5.0


### PR DESCRIPTION
* Introducing `Uncancellable` for, well, cancellable futures which actually can't be cancelled
* Simpler handling of `onCancel`
* The default execution context 
* Unit tests

TBD:
* More unit tests
* Rewriting `CancellableFuture` as an abstract class with two implementations: `Cancellable` and `Uncancellable`.